### PR TITLE
feature/user-query

### DIFF
--- a/src/api/schema/login/login.test.ts
+++ b/src/api/schema/login/login.test.ts
@@ -92,7 +92,6 @@ describe('GraphQL: Login - mutation login', () => {
     const res = await Request(loginMutation, { data: input });
 
     expect(res.body.data).to.be.null;
-    expect(res.body).to.own.property('errors');
     expect(res.body.errors).to.deep.include({ code: 404, message: 'Email não cadastrado' });
   });
 
@@ -108,7 +107,6 @@ describe('GraphQL: Login - mutation login', () => {
     const res = await Request(loginMutation, { data: input });
 
     expect(res.body.data).to.be.null;
-    expect(res.body).to.own.property('errors');
     expect(res.body.errors).to.deep.include({ code: 401, message: 'Email ou senha incorretos' });
   });
 });

--- a/src/api/schema/user/user.resolver.ts
+++ b/src/api/schema/user/user.resolver.ts
@@ -10,7 +10,7 @@ export class UserResolver {
   @Authorized()
   async user(@Arg('id') id: string) {
     try {
-      const user = UserEntity.findOne(id);
+      const user = UserEntity.findOneOrFail(id);
       return user;
     } catch (error) {
       throw new BaseError(404, 'Usuário não encontrado');

--- a/src/api/schema/user/user.resolver.ts
+++ b/src/api/schema/user/user.resolver.ts
@@ -6,7 +6,19 @@ import { BaseError } from '@api/error/base-error';
 
 @Resolver()
 export class UserResolver {
+  @Query(() => UserType)
+  @Authorized()
+  async user(@Arg('id') id: string) {
+    try {
+      const user = UserEntity.findOne(id);
+      return user;
+    } catch (error) {
+      throw new BaseError(404, 'Usuário não encontrado');
+    }
+  }
+
   @Query(() => [UserType])
+  @Authorized()
   async users() {
     return UserEntity.find();
   }

--- a/src/api/schema/user/user.resolver.ts
+++ b/src/api/schema/user/user.resolver.ts
@@ -9,13 +9,7 @@ export class UserResolver {
   @Query(() => UserType)
   @Authorized()
   async user(@Arg('id') id: string) {
-    let user: UserEntity | undefined;
-
-    try {
-      user = await UserEntity.findOne(id);
-    } catch (err) {
-      throw new BaseError(400, 'Identificador de usuário inválido');
-    }
+    const user: UserEntity | undefined = await UserEntity.findOne(id);
 
     if (user) {
       return user;

--- a/src/api/schema/user/user.resolver.ts
+++ b/src/api/schema/user/user.resolver.ts
@@ -9,12 +9,19 @@ export class UserResolver {
   @Query(() => UserType)
   @Authorized()
   async user(@Arg('id') id: string) {
+    let user: UserEntity | undefined;
+
     try {
-      const user = UserEntity.findOneOrFail(id);
-      return user;
-    } catch (error) {
-      throw new BaseError(404, 'Usuário não encontrado');
+      user = await UserEntity.findOne(id);
+    } catch (err) {
+      throw new BaseError(400, 'Identificador de usuário inválido');
     }
+
+    if (user) {
+      return user;
+    }
+
+    throw new BaseError(404, 'Usuário inexistente');
   }
 
   @Query(() => [UserType])

--- a/src/api/schema/user/user.test.ts
+++ b/src/api/schema/user/user.test.ts
@@ -71,25 +71,6 @@ describe('GraphQL: User - query user', () => {
     });
   });
 
-  it('should trigger invalid id error', async () => {
-    const user = UserEntity.create({
-      name: 'Padmé Amidala',
-      email: 'padmeia@yahoo.com',
-      password: 'padead123',
-      birthDate: new Date(),
-    });
-    await user.save();
-
-    const token = await getTestToken();
-    const res = await Request(userQuery, { id: 'wrong id' }, token);
-
-    expect(res.body.data).to.be.null;
-    expect(res.body.errors).to.deep.include({
-      code: 400,
-      message: 'Identificador de usuário inválido',
-    });
-  });
-
   it('should trigger token not sent error', async () => {
     const user = UserEntity.create({
       name: 'Padmé Amidala',

--- a/src/api/schema/user/user.test.ts
+++ b/src/api/schema/user/user.test.ts
@@ -5,7 +5,6 @@ import { expect } from 'chai';
 import { UserInput } from '@api/schema/user/user.input';
 import { UserEntity } from '@data/entity/user.entity';
 import { Authenticator } from '@api/server/authenticator';
-import { UserType } from './user.type';
 
 const userQuery = `
 query user ($id: String!) {

--- a/src/api/schema/user/user.test.ts
+++ b/src/api/schema/user/user.test.ts
@@ -7,6 +7,16 @@ import { UserEntity } from '@data/entity/user.entity';
 import { Authenticator } from '@api/server/authenticator';
 import { UserType } from './user.type';
 
+const userQuery = `
+query user ($id: String!) {
+  user(id : $id) {
+    id
+    name
+    email
+    birthDate
+  }
+}`;
+
 const createUserMutation = `
 mutation createUser($data: UserInput!) {
   createUser(data: $data) {
@@ -17,7 +27,7 @@ mutation createUser($data: UserInput!) {
   }
 }`;
 
-const getToken = async (): Promise<string> => {
+const getTestToken = async (): Promise<string> => {
   const user = UserEntity.create({
     name: 'Luke Skywalker',
     email: 'skylwalker.top@gmail.com',
@@ -29,7 +39,30 @@ const getToken = async (): Promise<string> => {
   return Authenticator.getJWT({ id: user.id });
 };
 
-describe('GraphQL: User - createUser', () => {
+describe('GraphQL: User - query user', () => {
+  it('should return a user successfully', async () => {
+    const user = UserEntity.create({
+      name: 'Padmé Amidala',
+      email: 'padmeia@yahoo.com',
+      password: 'padead123',
+      birthDate: new Date(),
+    });
+    user.save();
+
+    const token = await getTestToken();
+    const res = await Request(userQuery, { id: user.id }, token);
+
+    expect(res.body).to.not.own.property('errors');
+    expect(res.body.data.user).to.include({
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      birthDate: user.birthDate.toISOString(),
+    });
+  });
+});
+
+describe('GraphQL: User - mutation createUser', () => {
   it('should create user successfully', async () => {
     const input: UserInput = {
       name: 'Padmé Amidala',
@@ -38,7 +71,7 @@ describe('GraphQL: User - createUser', () => {
       birthDate: new Date(),
     };
 
-    const token = await getToken();
+    const token = await getTestToken();
     const res = await Request(createUserMutation, { data: input }, token);
 
     expect(res.body).to.not.own.property('errors');
@@ -133,7 +166,7 @@ describe('GraphQL: User - createUser', () => {
       birthDate: new Date(),
     };
 
-    const token = await getToken();
+    const token = await getTestToken();
     const res = await Request(createUserMutation, { data: input }, token);
 
     expect(res.body.data).to.be.null;
@@ -149,7 +182,7 @@ describe('GraphQL: User - createUser', () => {
       birthDate: new Date(),
     };
 
-    const token = await getToken();
+    const token = await getTestToken();
     const res = await Request(createUserMutation, { data: input }, token);
 
     expect(res.body.data).to.be.null;
@@ -171,7 +204,7 @@ describe('GraphQL: User - createUser', () => {
       birthDate: new Date(),
     };
 
-    const token = await getToken();
+    const token = await getTestToken();
     const res = await Request(createUserMutation, { data: input }, token);
 
     expect(res.body.data).to.be.null;

--- a/src/api/schema/user/user.test.ts
+++ b/src/api/schema/user/user.test.ts
@@ -47,7 +47,7 @@ describe('GraphQL: User - query user', () => {
       password: 'padead123',
       birthDate: new Date(),
     });
-    user.save();
+    await user.save();
 
     const token = await getTestToken();
     const res = await Request(userQuery, { id: user.id }, token);
@@ -58,6 +58,18 @@ describe('GraphQL: User - query user', () => {
       name: user.name,
       email: user.email,
       birthDate: user.birthDate.toISOString(),
+    });
+  });
+
+  it('should trigger unknown user error', async () => {
+    const token = await getTestToken();
+    const res = await Request(userQuery, { id: '00000000-0000-0000-0000-000000000000' }, token);
+
+    expect(res.body.data).to.be.null;
+    expect(res.body).to.own.property('errors');
+    expect(res.body.errors).to.deep.include({
+      code: 404,
+      message: 'Usuário inexistente',
     });
   });
 });

--- a/src/api/schema/user/user.test.ts
+++ b/src/api/schema/user/user.test.ts
@@ -72,6 +72,26 @@ describe('GraphQL: User - query user', () => {
       message: 'Usuário inexistente',
     });
   });
+
+  it('should trigger invalid id error', async () => {
+    const user = UserEntity.create({
+      name: 'Padmé Amidala',
+      email: 'padmeia@yahoo.com',
+      password: 'padead123',
+      birthDate: new Date(),
+    });
+    await user.save();
+
+    const token = await getTestToken();
+    const res = await Request(userQuery, { id: 'wrong id' }, token);
+
+    expect(res.body.data).to.be.null;
+    expect(res.body).to.own.property('errors');
+    expect(res.body.errors).to.deep.include({
+      code: 400,
+      message: 'Identificador de usuário inválido',
+    });
+  });
 });
 
 describe('GraphQL: User - mutation createUser', () => {


### PR DESCRIPTION
Foi feita a query com o decorator `@Authorized()` e utilizando o método `findOne()`. Dois erros foram tratados: quando o id enviado é inválido e quando o usuário requisitado não existe. Feito isso, foram criados casos de testes para quando o usuário é retornado com sucesso e para quando há algum erro (incluindo erros de autenticação).