### PR TITLE
feature/users-pagination

### DIFF
--- a/src/api/schema/pagination/page.input.ts
+++ b/src/api/schema/pagination/page.input.ts
@@ -11,4 +11,15 @@ export class PageInput {
   @Min(1, { message: 'O número limite mínimo é 1' })
   @Max(100, { message: 'O número limite máximo é 100' })
   limit!: number;
+
+  static fixInput = (page: PageInput | undefined): PageInput => {
+    if (!page) {
+      page = new PageInput();
+    }
+
+    page.offset = page.offset != undefined ? page.offset : 0;
+    page.limit = page.limit != undefined ? page.limit : 10;
+
+    return page;
+  };
 }

--- a/src/api/schema/pagination/page.input.ts
+++ b/src/api/schema/pagination/page.input.ts
@@ -1,13 +1,14 @@
 import { Field, InputType, Int } from 'type-graphql';
-import { Min } from 'class-validator';
+import { Max, Min } from 'class-validator';
 
 @InputType()
 export class PageInput {
   @Field(() => Int, { description: 'Número de elementos ignorados', nullable: true })
-  @Min(0, { message: 'O número de elementos ignorados precisa ser igual ou maior que zero' })
+  @Min(0, { message: 'O número mínimo de elementos ignorados é 0' })
   offset?: number;
 
   @Field(() => Int, { description: 'Número máximo de elementos a serem retornados', defaultValue: 10 })
-  @Min(0, { message: 'O número limite precisa ser igual ou maior que zero' })
+  @Min(1, { message: 'O número limite mínimo é 1' })
+  @Max(100, { message: 'O número limite máximo é 100' })
   limit!: number;
 }

--- a/src/api/schema/pagination/page.input.ts
+++ b/src/api/schema/pagination/page.input.ts
@@ -1,0 +1,13 @@
+import { Field, InputType, Int } from 'type-graphql';
+import { Min } from 'class-validator';
+
+@InputType()
+export class PageInput {
+  @Field(() => Int, { description: 'Número de elementos ignorados', nullable: true })
+  @Min(0, { message: 'O número de elementos ignorados precisa ser igual ou maior que zero' })
+  offset?: number;
+
+  @Field(() => Int, { description: 'Número máximo de elementos a serem retornados', defaultValue: 10 })
+  @Min(0, { message: 'O número limite precisa ser igual ou maior que zero' })
+  limit!: number;
+}

--- a/src/api/schema/pagination/page.type.ts
+++ b/src/api/schema/pagination/page.type.ts
@@ -1,4 +1,6 @@
+import { isNumber } from 'class-validator';
 import { Field, Int, ObjectType } from 'type-graphql';
+import { PageInput } from './page.input';
 
 @ObjectType()
 export class PageType {
@@ -16,4 +18,21 @@ export class PageType {
 
   @Field({ description: 'Indicate if there is a previous page' })
   hasPreviousPage!: boolean;
+
+  static GetPageFromInput = (page: PageInput | undefined, count: number): PageType => {
+    if (!page) {
+      page = new PageInput();
+    }
+
+    page.offset = page.offset != undefined ? page.offset : 0;
+    page.limit = page.limit != undefined ? page.limit : 10;
+
+    return {
+      count: count,
+      limit: page.limit,
+      offset: page.offset,
+      hasNextPage: page.limit == 0 ? false : page.offset + page.limit < count,
+      hasPreviousPage: page.offset > 0 && count > 0,
+    };
+  };
 }

--- a/src/api/schema/pagination/page.type.ts
+++ b/src/api/schema/pagination/page.type.ts
@@ -19,6 +19,10 @@ export class PageType {
   @Field({ description: 'Indicate if there is a previous page' })
   hasPreviousPage!: boolean;
 
+  static propertiestoString = (): string => {
+    return `count offset limit hasNextPage hasPreviousPage`;
+  };
+
   static getPageFromInput = (page: PageInput, count: number): PageType => {
     page.offset = page.offset != undefined ? page.offset : 0;
 

--- a/src/api/schema/pagination/page.type.ts
+++ b/src/api/schema/pagination/page.type.ts
@@ -1,0 +1,19 @@
+import { Field, Int, ObjectType } from 'type-graphql';
+
+@ObjectType()
+export class PageType {
+  @Field(() => Int, { description: 'Total number of elements', nullable: true })
+  count?: number;
+
+  @Field(() => Int, { description: 'Number of skipped elements' })
+  offset!: number;
+
+  @Field(() => Int, { description: 'Maximum number of elements' })
+  limit!: number;
+
+  @Field({ description: 'Indicate if there is a posterior page' })
+  hasNextPage!: boolean;
+
+  @Field({ description: 'Indicate if there is a previous page' })
+  hasPreviousPage!: boolean;
+}

--- a/src/api/schema/pagination/page.type.ts
+++ b/src/api/schema/pagination/page.type.ts
@@ -19,13 +19,8 @@ export class PageType {
   @Field({ description: 'Indicate if there is a previous page' })
   hasPreviousPage!: boolean;
 
-  static GetPageFromInput = (page: PageInput | undefined, count: number): PageType => {
-    if (!page) {
-      page = new PageInput();
-    }
-
+  static getPageFromInput = (page: PageInput, count: number): PageType => {
     page.offset = page.offset != undefined ? page.offset : 0;
-    page.limit = page.limit != undefined ? page.limit : 10;
 
     return {
       count: count,

--- a/src/api/schema/user/create-user.test.ts
+++ b/src/api/schema/user/create-user.test.ts
@@ -5,15 +5,11 @@ import { expect } from 'chai';
 import { UserInput } from '@api/schema/user/user.input';
 import { UserEntity } from '@data/entity/user.entity';
 import { Authenticator } from '@api/server/authenticator';
+import { UserType } from './user.type';
 
 const createUserMutation = `
 mutation createUser($data: UserInput!) {
-  createUser(data: $data) {
-    id
-    name
-    email
-    birthDate
-  }
+  createUser(data: $data) { ${UserType.propertiestoString()} }
 }`;
 
 describe('GraphQL: User - mutation createUser', () => {

--- a/src/api/schema/user/user.resolver.ts
+++ b/src/api/schema/user/user.resolver.ts
@@ -23,17 +23,15 @@ export class UserResolver {
 
   @Query(() => UsersType)
   async users(@Arg('page', () => PageInput, { nullable: true }) page: PageInput) {
-    const count = await UserEntity.count();
+    page = PageInput.fixInput(page);
 
-    page = PageType.GetPageFromInput(page, count);
-
-    const users = await UserEntity.find({
+    const [users, count] = await UserEntity.findAndCount({
       order: { name: 'ASC' },
       skip: page.offset,
       take: page.limit,
     });
 
-    return { users, page };
+    return { users, page: PageType.getPageFromInput(page, count) };
   }
 
   @Mutation(() => UserType)

--- a/src/api/schema/user/user.test.ts
+++ b/src/api/schema/user/user.test.ts
@@ -3,15 +3,11 @@ import { expect } from 'chai';
 
 import { UserEntity } from '@data/entity/user.entity';
 import { Authenticator } from '@api/server/authenticator';
+import { UserType } from './user.type';
 
 const userQuery = `
 query user ($id: String!) {
-  user(id : $id) {
-    id
-    name
-    email
-    birthDate
-  }
+  user(id : $id) { ${UserType.propertiestoString()} }
 }`;
 
 describe('GraphQL: User - query user', () => {

--- a/src/api/schema/user/user.type.ts
+++ b/src/api/schema/user/user.type.ts
@@ -13,4 +13,8 @@ export class UserType {
 
   @Field(() => Date, { description: 'User birth date' })
   birthDate!: Date;
+
+  static propertiestoString = (): string => {
+    return 'id name email birthDate';
+  };
 }

--- a/src/api/schema/user/users.test.ts
+++ b/src/api/schema/user/users.test.ts
@@ -4,14 +4,24 @@ import { UserSeed } from '@data/seed/user.seed';
 import { UserEntity } from '@data/entity/user.entity';
 
 const usersQuery = `
-query users ($limit: Int) {
-  users(limit : $limit) {
-    id
-    name
-    email
-    birthDate
+query users($page: PageInput) {
+  users(page: $page) {
+    page {
+      count
+      offset
+      limit
+      hasNextPage
+      hasPreviousPage
+    }
+    users {
+      id
+      name
+      email
+      birthDate
+    }
   }
-}`;
+}
+`;
 
 const sortUsersByName = (users: UserEntity[]): UserEntity[] => {
   const sorted = [...users];
@@ -26,76 +36,147 @@ const sortUsersByName = (users: UserEntity[]): UserEntity[] => {
 describe('GraphQL: User - query users', function () {
   this.timeout(5000);
 
-  it('should successfully return 10 users without a defined limit', async () => {
-    let users = await UserSeed(10);
-    users = sortUsersByName(users);
+  it('should successfully return 10 users without defining a page', async () => {
+    let seedUsers = await UserSeed(10);
+    seedUsers = sortUsersByName(seedUsers);
 
     const res = await createRequest(usersQuery);
 
     expect(res.body).to.not.own.property('errors');
-    expect(res.body.data.users.length).to.be.eq(users.length);
 
-    for (let i = 0; i < users.length; i++) {
-      expect(res.body.data.users[i]).to.be.deep.eq({
-        id: users[i].id,
-        name: users[i].name,
-        email: users[i].email,
-        birthDate: users[i].birthDate.toISOString(),
+    const users = res.body.data.users.users;
+    const page = res.body.data.users.page;
+
+    expect(users.length).to.be.eq(seedUsers.length);
+    expect(page).to.be.deep.eq({
+      count: 10,
+      offset: 0,
+      limit: 10,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    });
+
+    for (let i = 0; i < seedUsers.length; i++) {
+      expect(users[i]).to.be.deep.eq({
+        id: seedUsers[i].id,
+        name: seedUsers[i].name,
+        email: seedUsers[i].email,
+        birthDate: seedUsers[i].birthDate.toISOString(),
       });
     }
   });
 
-  it('should successfully return 5 users with a defined limit', async () => {
-    let users = await UserSeed(10);
-    users = sortUsersByName(users);
-    users = users.slice(0, 5);
+  it('should successfully return 5 users from beginning defining a limit', async () => {
+    let seedUsers = await UserSeed(10);
+    seedUsers = sortUsersByName(seedUsers);
+    seedUsers = seedUsers.slice(0, 5);
 
-    const res = await createRequest(usersQuery, { limit: 5 });
+    const res = await createRequest(usersQuery, { page: { limit: 5 } });
 
     expect(res.body).to.not.own.property('errors');
-    expect(res.body.data.users.length).to.be.eq(users.length);
 
-    for (let i = 0; i < users.length; i++) {
-      expect(res.body.data.users[i]).to.be.deep.eq({
-        id: users[i].id,
-        name: users[i].name,
-        email: users[i].email,
-        birthDate: users[i].birthDate.toISOString(),
+    const users = res.body.data.users.users;
+    const page = res.body.data.users.page;
+
+    expect(users.length).to.be.eq(seedUsers.length);
+    expect(page).to.be.deep.eq({
+      count: 10,
+      offset: 0,
+      limit: 5,
+      hasNextPage: true,
+      hasPreviousPage: false,
+    });
+
+    for (let i = 0; i < seedUsers.length; i++) {
+      expect(users[i]).to.be.deep.eq({
+        id: seedUsers[i].id,
+        name: seedUsers[i].name,
+        email: seedUsers[i].email,
+        birthDate: seedUsers[i].birthDate.toISOString(),
       });
     }
   });
 
-  it('it should successfully return 10 users with an overly defined limit', async () => {
-    let users = await UserSeed(10);
-    users = sortUsersByName(users);
+  it('should successfully return 8 users defining an offset and a limit', async () => {
+    let seedUsers = await UserSeed(10);
+    seedUsers = sortUsersByName(seedUsers);
+    seedUsers = seedUsers.slice(2, 7);
 
-    const res = await createRequest(usersQuery, { limit: 100 });
+    const res = await createRequest(usersQuery, { page: { offset: 2, limit: 5 } });
 
     expect(res.body).to.not.own.property('errors');
-    expect(res.body.data.users.length).to.be.eq(users.length);
 
-    for (let i = 0; i < users.length; i++) {
-      expect(res.body.data.users[i]).to.be.deep.eq({
-        id: users[i].id,
-        name: users[i].name,
-        email: users[i].email,
-        birthDate: users[i].birthDate.toISOString(),
+    const users = res.body.data.users.users;
+    const page = res.body.data.users.page;
+
+    expect(users.length).to.be.eq(seedUsers.length);
+    expect(page).to.be.deep.eq({
+      count: 10,
+      offset: 2,
+      limit: 5,
+      hasNextPage: true,
+      hasPreviousPage: true,
+    });
+
+    for (let i = 0; i < seedUsers.length; i++) {
+      expect(users[i]).to.be.deep.eq({
+        id: seedUsers[i].id,
+        name: seedUsers[i].name,
+        email: seedUsers[i].email,
+        birthDate: seedUsers[i].birthDate.toISOString(),
+      });
+    }
+  });
+
+  it('it should successfully return all users defining no limit', async () => {
+    let seedUsers = await UserSeed(10);
+    seedUsers = sortUsersByName(seedUsers);
+
+    const res = await createRequest(usersQuery, { page: { limit: 0 } });
+
+    expect(res.body).to.not.own.property('errors');
+
+    const users = res.body.data.users.users;
+    const page = res.body.data.users.page;
+
+    expect(page).to.be.deep.eq({
+      count: 10,
+      offset: 0,
+      limit: 0,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    });
+
+    expect(users.length).to.be.eq(seedUsers.length);
+
+    for (let i = 0; i < seedUsers.length; i++) {
+      expect(users[i]).to.be.deep.eq({
+        id: seedUsers[i].id,
+        name: seedUsers[i].name,
+        email: seedUsers[i].email,
+        birthDate: seedUsers[i].birthDate.toISOString(),
       });
     }
   });
 
   it('it should trigger non-positive error', async () => {
-    const res = await createRequest(usersQuery, { limit: -10 });
+    const res = await createRequest(usersQuery, { page: { offset: -5, limit: -10 } });
 
     expect(res.body.data).to.be.null;
-    expect(res.body.errors).to.deep.include({
-      code: 400,
-      message: 'O limite não pode ser negativo',
-    });
+
+    const errorMessages = res.body.errors.map((error: { message: string }) => error.message);
+    expect(errorMessages).to.include('Argumentos inválidos');
+    const errorIndex = errorMessages.indexOf('Argumentos inválidos');
+
+    expect(res.body.errors[errorIndex]).to.own.property('details');
+    expect(res.body.errors[errorIndex].details).to.include(
+      'O número de elementos ignorados precisa ser igual ou maior que zero',
+    );
+    expect(res.body.errors[errorIndex].details).to.include('O número limite precisa ser igual ou maior que zero');
   });
 
   it('it should trigger non-integer error', async () => {
-    const res = await createRequest(usersQuery, { limit: 4.2 }, undefined, 400);
+    const res = await createRequest(usersQuery, { page: { offset: 4.2 } }, undefined, 400);
     expect(res.body.errors[0].message).to.includes('Int cannot represent non-integer value');
   });
 });

--- a/src/api/schema/user/users.test.ts
+++ b/src/api/schema/user/users.test.ts
@@ -2,23 +2,14 @@ import { createRequest } from '@test/create-request';
 import { expect } from 'chai';
 import { UserSeed } from '@data/seed/user.seed';
 import { UserEntity } from '@data/entity/user.entity';
+import { UserType } from './user.type';
+import { PageType } from '../pagination/page.type';
 
 const usersQuery = `
 query users($page: PageInput) {
   users(page: $page) {
-    page {
-      count
-      offset
-      limit
-      hasNextPage
-      hasPreviousPage
-    }
-    users {
-      id
-      name
-      email
-      birthDate
-    }
+    page { ${PageType.propertiestoString()} }
+    users { ${UserType.propertiestoString()} }
   }
 }
 `;

--- a/src/api/schema/user/users.test.ts
+++ b/src/api/schema/user/users.test.ts
@@ -211,7 +211,7 @@ describe('GraphQL: User - query users', function () {
     }
   });
 
-  it('it should trigger min offset validation error', async () => {
+  it('should trigger min offset validation error', async () => {
     const res = await createRequest(usersQuery, { page: { offset: -5 } });
 
     expect(res.body.data).to.be.null;
@@ -224,7 +224,7 @@ describe('GraphQL: User - query users', function () {
     expect(res.body.errors[errorIndex].details).to.include('O número mínimo de elementos ignorados é 0');
   });
 
-  it('it should trigger min limit validation error', async () => {
+  it('should trigger min limit validation error', async () => {
     const res = await createRequest(usersQuery, { page: { limit: 0 } });
 
     expect(res.body.data).to.be.null;
@@ -237,7 +237,7 @@ describe('GraphQL: User - query users', function () {
     expect(res.body.errors[errorIndex].details).to.include('O número limite mínimo é 1');
   });
 
-  it('it should trigger max limit validation error', async () => {
+  it('should trigger max limit validation error', async () => {
     const res = await createRequest(usersQuery, { page: { limit: 101 } });
 
     expect(res.body.data).to.be.null;
@@ -250,7 +250,7 @@ describe('GraphQL: User - query users', function () {
     expect(res.body.errors[errorIndex].details).to.include('O número limite máximo é 100');
   });
 
-  it('it should trigger non-integer error', async () => {
+  it('should trigger non-integer error', async () => {
     const res = await createRequest(usersQuery, { page: { offset: 4.2 } }, undefined, 400);
     expect(res.body.errors[0].message).to.includes('Int cannot represent non-integer value');
   });

--- a/src/api/schema/user/users.type.ts
+++ b/src/api/schema/user/users.type.ts
@@ -1,0 +1,9 @@
+import { ObjectType, Field, ID } from 'type-graphql';
+import { PageType } from '@api/schema/pagination/page.type';
+import { UserType } from './user.type';
+
+@ObjectType()
+export class UsersType extends PageType {
+  @Field(() => [UserType], { description: 'List of users' })
+  users!: [UserType];
+}

--- a/src/api/schema/user/users.type.ts
+++ b/src/api/schema/user/users.type.ts
@@ -1,9 +1,12 @@
-import { ObjectType, Field, ID } from 'type-graphql';
+import { ObjectType, Field, Int } from 'type-graphql';
 import { PageType } from '@api/schema/pagination/page.type';
 import { UserType } from './user.type';
 
 @ObjectType()
-export class UsersType extends PageType {
+export class UsersType {
   @Field(() => [UserType], { description: 'List of users' })
   users!: [UserType];
+
+  @Field(() => PageType, { description: 'Page data' })
+  page!: PageType;
 }


### PR DESCRIPTION
Foi criado um `input` e um `type` para páginas, além de ter sido criado um `type` para `users` contendo as informações da página e a lista de usuários dessa página. Feito isso, a query `users` foi ajustada para que os usuários fossem enviados com as informações da página em questão. Foram criados casos de testes para verificar erros e resultados de diferentes combinações de `offset` e `limit`.